### PR TITLE
Keystore extension consistency fix

### DIFF
--- a/v/v1.7.2/docs/_print/index.html
+++ b/v/v1.7.2/docs/_print/index.html
@@ -1560,7 +1560,7 @@ Full key:
   <span style="color:#ce5c00;font-weight:bold">]</span>
 <span style="color:#ce5c00;font-weight:bold">}</span>
 </code></pre></div><p>Save the output of the above command (minus the <code>Full key:</code> initial text) in a
-file, e.g. <code>iam-keystore.jwks</code>.</p>
+file, e.g. <code>iam-keystore.jks</code>.</p>
 
 </div>
 
@@ -1735,7 +1735,7 @@ manually to the organisation using the IAM dashboard if you prefer).</p>
 <span style="color:#000">IAM_BASE_URL</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_ISSUER</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_USE_FORWARDED_HEADERS</span><span style="color:#ce5c00;font-weight:bold">=</span><span style="color:#204a87">true</span>
-<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jwks
+<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jks
 <span style="color:#000">IAM_DB_HOST</span><span style="color:#ce5c00;font-weight:bold">=</span>db
 <span style="color:#000">IAM_DB_NAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam
 <span style="color:#000">IAM_DB_USERNAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam

--- a/v/v1.7.2/docs/getting-started/_print/index.html
+++ b/v/v1.7.2/docs/getting-started/_print/index.html
@@ -478,7 +478,7 @@ Full key:
   <span style="color:#ce5c00;font-weight:bold">]</span>
 <span style="color:#ce5c00;font-weight:bold">}</span>
 </code></pre></div><p>Save the output of the above command (minus the <code>Full key:</code> initial text) in a
-file, e.g. <code>iam-keystore.jwks</code>.</p>
+file, e.g. <code>iam-keystore.jks</code>.</p>
 
 </div>
 
@@ -653,7 +653,7 @@ manually to the organisation using the IAM dashboard if you prefer).</p>
 <span style="color:#000">IAM_BASE_URL</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_ISSUER</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_USE_FORWARDED_HEADERS</span><span style="color:#ce5c00;font-weight:bold">=</span><span style="color:#204a87">true</span>
-<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jwks
+<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jks
 <span style="color:#000">IAM_DB_HOST</span><span style="color:#ce5c00;font-weight:bold">=</span>db
 <span style="color:#000">IAM_DB_NAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam
 <span style="color:#000">IAM_DB_USERNAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam

--- a/v/v1.7.2/docs/getting-started/basic_setup/_print/index.html
+++ b/v/v1.7.2/docs/getting-started/basic_setup/_print/index.html
@@ -181,7 +181,7 @@ manually to the organisation using the IAM dashboard if you prefer).</p>
 <span style="color:#000">IAM_BASE_URL</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_ISSUER</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_USE_FORWARDED_HEADERS</span><span style="color:#ce5c00;font-weight:bold">=</span><span style="color:#204a87">true</span>
-<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jwks
+<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jks
 <span style="color:#000">IAM_DB_HOST</span><span style="color:#ce5c00;font-weight:bold">=</span>db
 <span style="color:#000">IAM_DB_NAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam
 <span style="color:#000">IAM_DB_USERNAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam

--- a/v/v1.7.2/docs/getting-started/basic_setup/index.html
+++ b/v/v1.7.2/docs/getting-started/basic_setup/index.html
@@ -1736,7 +1736,7 @@ manually to the organisation using the IAM dashboard if you prefer).</p>
 <span style="color:#000">IAM_BASE_URL</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_ISSUER</span><span style="color:#ce5c00;font-weight:bold">=</span>https://iam.local.io
 <span style="color:#000">IAM_USE_FORWARDED_HEADERS</span><span style="color:#ce5c00;font-weight:bold">=</span><span style="color:#204a87">true</span>
-<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jwks
+<span style="color:#000">IAM_KEY_STORE_LOCATION</span><span style="color:#ce5c00;font-weight:bold">=</span>file:/iam-keystore.jks
 <span style="color:#000">IAM_DB_HOST</span><span style="color:#ce5c00;font-weight:bold">=</span>db
 <span style="color:#000">IAM_DB_NAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam
 <span style="color:#000">IAM_DB_USERNAME</span><span style="color:#ce5c00;font-weight:bold">=</span>iam

--- a/v/v1.7.2/docs/getting-started/docker/_print/index.html
+++ b/v/v1.7.2/docs/getting-started/docker/_print/index.html
@@ -190,7 +190,7 @@ reference</a> for a description of the variables.</p>
 </span><span style="color:#4e9a06"></span>  --name iam-login-service <span style="color:#4e9a06">\
 </span><span style="color:#4e9a06"></span>  --net<span style="color:#ce5c00;font-weight:bold">=</span>iam -p 8080:8080 <span style="color:#4e9a06">\
 </span><span style="color:#4e9a06"></span>  --env-file<span style="color:#ce5c00;font-weight:bold">=</span>/path/to/iam-login-service/env <span style="color:#4e9a06">\
-</span><span style="color:#4e9a06"></span>  -v /path/to/keystore.jks:/keystore.jks:ro <span style="color:#4e9a06">\
+</span><span style="color:#4e9a06"></span>  -v /path/to/iam-keystore.jks:/keystore.jks:ro <span style="color:#4e9a06">\
 </span><span style="color:#4e9a06"></span>  indigoiam/iam-login-service:v1.7.2
 </code></pre></div><p>Check the logs with:</p>
 <div class="highlight"><pre tabindex="0" style="background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-shell" data-lang="shell">$ docker logs -f iam-login-service

--- a/v/v1.7.2/docs/getting-started/docker/index.html
+++ b/v/v1.7.2/docs/getting-started/docker/index.html
@@ -1745,7 +1745,7 @@ reference</a> for a description of the variables.</p>
 </span><span style="color:#4e9a06"></span>  --name iam-login-service <span style="color:#4e9a06">\
 </span><span style="color:#4e9a06"></span>  --net<span style="color:#ce5c00;font-weight:bold">=</span>iam -p 8080:8080 <span style="color:#4e9a06">\
 </span><span style="color:#4e9a06"></span>  --env-file<span style="color:#ce5c00;font-weight:bold">=</span>/path/to/iam-login-service/env <span style="color:#4e9a06">\
-</span><span style="color:#4e9a06"></span>  -v /path/to/keystore.jks:/keystore.jks:ro <span style="color:#4e9a06">\
+</span><span style="color:#4e9a06"></span>  -v /path/to/iam-keystore.jks:/keystore.jks:ro <span style="color:#4e9a06">\
 </span><span style="color:#4e9a06"></span>  indigoiam/iam-login-service:v1.7.2
 </code></pre></div><p>Check the logs with:</p>
 <div class="highlight"><pre tabindex="0" style="background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-shell" data-lang="shell">$ docker logs -f iam-login-service

--- a/v/v1.7.2/docs/getting-started/jwk/_print/index.html
+++ b/v/v1.7.2/docs/getting-started/jwk/_print/index.html
@@ -200,7 +200,7 @@ Full key:
   <span style="color:#ce5c00;font-weight:bold">]</span>
 <span style="color:#ce5c00;font-weight:bold">}</span>
 </code></pre></div><p>Save the output of the above command (minus the <code>Full key:</code> initial text) in a
-file, e.g. <code>iam-keystore.jwks</code>.</p>
+file, e.g. <code>iam-keystore.jks</code>.</p>
 
 </div>
 </div>

--- a/v/v1.7.2/docs/getting-started/jwk/index.html
+++ b/v/v1.7.2/docs/getting-started/jwk/index.html
@@ -1755,7 +1755,7 @@ Full key:
   <span style="color:#ce5c00;font-weight:bold">]</span>
 <span style="color:#ce5c00;font-weight:bold">}</span>
 </code></pre></div><p>Save the output of the above command (minus the <code>Full key:</code> initial text) in a
-file, e.g. <code>iam-keystore.jwks</code>.</p>
+file, e.g. <code>iam-keystore.jks</code>.</p>
 
         <div class="section-index">
     


### PR DESCRIPTION
- Also use the same file name between the `jwk` page and the `basic-setup` page.
- 
Fixes #1 
