### PR TITLE
1.7.2: fix broken references

### DIFF
--- a/v/v1.7.2/docs/_print/index.html
+++ b/v/v1.7.2/docs/_print/index.html
@@ -1757,7 +1757,7 @@ we recommend using the same setting as <code>IAM_BASE_URL</code>, i.e.
 <li><code>IAM_USE_FORWARDED_HEADERS</code> tells the IAM that whether it lives behind a reverse
 proxy (i.e., NGINX); in production the value is typically <code>true</code>;</li>
 <li><code>IAM_KEY_STORE_LOCATION</code> is the location of the JSON Web keystore generated
-as explained <a href="docs/getting-started/jwk">here</a>;</li>
+as explained <a href="/v/v1.7.2/docs/getting-started/jwk">here</a>;</li>
 <li><code>IAM_DB_*</code> are variables used to set the database endpoint and provide
 database access credentials;</li>
 <li><code>IAM_NOTIFICATION_FROM</code> sets the sender of administrative notification sent

--- a/v/v1.7.2/docs/getting-started/_print/index.html
+++ b/v/v1.7.2/docs/getting-started/_print/index.html
@@ -675,7 +675,7 @@ we recommend using the same setting as <code>IAM_BASE_URL</code>, i.e.
 <li><code>IAM_USE_FORWARDED_HEADERS</code> tells the IAM that whether it lives behind a reverse
 proxy (i.e., NGINX); in production the value is typically <code>true</code>;</li>
 <li><code>IAM_KEY_STORE_LOCATION</code> is the location of the JSON Web keystore generated
-as explained <a href="docs/getting-started/jwk">here</a>;</li>
+as explained <a href="/v/v1.7.2/docs/getting-started/jwk">here</a>;</li>
 <li><code>IAM_DB_*</code> are variables used to set the database endpoint and provide
 database access credentials;</li>
 <li><code>IAM_NOTIFICATION_FROM</code> sets the sender of administrative notification sent

--- a/v/v1.7.2/docs/getting-started/basic_setup/_print/index.html
+++ b/v/v1.7.2/docs/getting-started/basic_setup/_print/index.html
@@ -203,7 +203,7 @@ we recommend using the same setting as <code>IAM_BASE_URL</code>, i.e.
 <li><code>IAM_USE_FORWARDED_HEADERS</code> tells the IAM that whether it lives behind a reverse
 proxy (i.e., NGINX); in production the value is typically <code>true</code>;</li>
 <li><code>IAM_KEY_STORE_LOCATION</code> is the location of the JSON Web keystore generated
-as explained <a href="docs/getting-started/jwk">here</a>;</li>
+as explained <a href="/v/v1.7.2/docs/getting-started/jwk">here</a>;</li>
 <li><code>IAM_DB_*</code> are variables used to set the database endpoint and provide
 database access credentials;</li>
 <li><code>IAM_NOTIFICATION_FROM</code> sets the sender of administrative notification sent

--- a/v/v1.7.2/docs/getting-started/basic_setup/index.html
+++ b/v/v1.7.2/docs/getting-started/basic_setup/index.html
@@ -1758,7 +1758,7 @@ we recommend using the same setting as <code>IAM_BASE_URL</code>, i.e.
 <li><code>IAM_USE_FORWARDED_HEADERS</code> tells the IAM that whether it lives behind a reverse
 proxy (i.e., NGINX); in production the value is typically <code>true</code>;</li>
 <li><code>IAM_KEY_STORE_LOCATION</code> is the location of the JSON Web keystore generated
-as explained <a href="docs/getting-started/jwk">here</a>;</li>
+as explained <a href="/v/v1.7.2/docs/getting-started/jwk">here</a>;</li>
 <li><code>IAM_DB_*</code> are variables used to set the database endpoint and provide
 database access credentials;</li>
 <li><code>IAM_NOTIFICATION_FROM</code> sets the sender of administrative notification sent


### PR DESCRIPTION
- Use absolute URLs are the sitre URL doesn't resolve to the appropriate location